### PR TITLE
Bump typescript version from  ~2.8.3 to 3.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "swagger-jsdoc": "^1.9.7",
     "ts-loader": "^4.3.0",
     "ts-node": "^6.0.3",
-    "typescript": "~2.8.3",
+    "typescript": "3.1.6",
     "url-parse": "^1.4.1",
     "webpack": "^4.8.1",
     "webpack-cli": "^3.0.3",


### PR DESCRIPTION
Upgrade typescript to fix error that occurs during npm install

ERROR in /tmp/cosmosdb-node-mongodb-rest-service/node_modules/@types/superagent/index.d.ts
[tsl] ERROR in /tmp/cosmosdb-node-mongodb-rest-service/node_modules/@types/superagent/index.d.ts(17,1)
      TS1084: Invalid 'reference' directive syntax.