### PR TITLE
Change keepAlive value from int to bool

### DIFF
--- a/src/config/mongoose.ts
+++ b/src/config/mongoose.ts
@@ -4,7 +4,7 @@ import { ConnectionOptions } from 'mongoose';
 import * as parse from 'url-parse';
 import { configs } from './environment';
 
-const options: ConnectionOptions = { keepAlive: 1 };
+const options: ConnectionOptions = { keepAlive: true };
 
 export async function connectDb(connectionString: string) {
   // URL encodes the password for a Cosmos DB connection string


### PR DESCRIPTION
Fix for

[tsl] ERROR in /tmp/cosmosdb-node-mongodb-rest-service/src/config/mongoose.ts(7,7)
      TS2322: Type '{ keepAlive: number; }' is not assignable to type 'ConnectionOptions'.
  Types of property 'keepAlive' are incompatible.
    Type 'number' is not assignable to type 'boolean'.